### PR TITLE
Convert all recipes to fabric tags

### DIFF
--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/dough.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/dough.json
@@ -2,7 +2,7 @@
   "type": "createdieselgenerators:basin_fermenting",
   "ingredients": [
     {
-      "item": "create:wheat_flour"
+      "tag": "c:wheat_flour"
     },
     {
       "fluid": "minecraft:water",

--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_apple.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_apple.json
@@ -5,19 +5,19 @@
       "item": "minecraft:apple"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "tag": "c:gold_ingots"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "tag": "c:gold_ingots"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "tag": "c:gold_ingots"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "tag": "c:gold_ingots"
     },
     {
-      "item": "minecraft:gold_ingot"
+      "tag": "c:gold_ingots"
     },
     {
       "fluid": "create:potion",

--- a/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_carrot.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/basin_fermenting/golden_carrot.json
@@ -5,19 +5,19 @@
       "item": "minecraft:carrot"
     },
     {
-      "tag": "c:nuggets/gold"
+      "tag": "c:gold_nuggets"
     },
     {
-      "tag": "c:nuggets/gold"
+      "tag": "c:gold_nuggets"
     },
     {
-      "tag": "c:nuggets/gold"
+      "tag": "c:gold_nuggets"
     },
     {
-      "tag": "c:nuggets/gold"
+      "tag": "c:gold_nuggets"
     },
     {
-      "tag": "c:nuggets/gold"
+      "tag": "c:gold_nuggets"
     },
     {
       "fluid": "create:potion",

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/canister.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/canister.json
@@ -13,7 +13,7 @@
       "item": "minecraft:barrel"
     },
     "Z": {
-      "item": "create:iron_sheet"
+      "tag": "c:iron_plates"
     }
   },
   "result": {

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/diesel_engine.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/diesel_engine.json
@@ -13,7 +13,7 @@
       "item": "minecraft:flint_and_steel"
     },
     "B": {
-      "item": "create:brass_block"
+      "tag": "c:brass_blocks"
     },
     "S": {
       "item": "minecraft:polished_blackstone_slab"

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/distillation_controller.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/distillation_controller.json
@@ -9,7 +9,7 @@
       "item": "create:andesite_alloy"
     },
     "I": {
-      "item": "create:iron_sheet"
+      "tag": "c:iron_plates"
     },
     "C": {
       "item": "minecraft:clock"

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/engine_piston.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/engine_piston.json
@@ -13,7 +13,7 @@
       "item": "create:shaft"
     },
     "Z": {
-      "item": "create:zinc_nugget"
+      "tag": "c:zinc_nuggets"
     }
   },
   "result": {

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/engine_turbocharger.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/engine_turbocharger.json
@@ -10,10 +10,10 @@
       "item": "create:andesite_alloy"
     },
     "S": {
-      "item": "create:iron_sheet"
+      "tag": "c:iron_plates"
     },
     "Z": {
-      "item": "create:zinc_ingot"
+      "tag": "c:zinc_ingots"
     },
     "P": {
       "item": "create:propeller"

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/huge_diesel_engine.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/huge_diesel_engine.json
@@ -10,10 +10,10 @@
       "item": "create:steam_engine"
     },
     "B": {
-      "item": "create:brass_block"
+      "tag": "c:brass_blocks"
     },
     "S": {
-      "item": "create:brass_sheet"
+      "tag": "c:brass_plates"
     },
     "F": {
       "item": "minecraft:flint_and_steel"

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/large_diesel_engine.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/large_diesel_engine.json
@@ -16,7 +16,7 @@
       "item": "minecraft:polished_blackstone_slab"
     },
     "S": {
-      "item": "create:brass_sheet"
+      "tag": "c:brass_plates"
     }
   },
   "result": {

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/lighter.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/lighter.json
@@ -13,10 +13,10 @@
       "item": "minecraft:flint_and_steel"
     },
     "S": {
-      "item": "create:brass_sheet"
+      "tag": "c:brass_plates"
     },
     "W": {
-      "item": "minecraft:string"
+      "tag": "c:string"
     }
   },
   "result": {

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/oil_barrel.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/oil_barrel.json
@@ -8,7 +8,7 @@
       "item": "minecraft:barrel"
     },
     "S": {
-      "item": "create:iron_sheet"
+      "tag": "c:iron_plates"
     }
   },
   "result": {

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/oil_scanner.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/oil_scanner.json
@@ -10,7 +10,7 @@
       "item": "create:andesite_alloy"
     },
     "S": {
-      "item": "create:iron_sheet"
+      "tag": "c:iron_plates"
     },
     "I": {
       "item": "iron_ingot"

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/pumpjack_bearing.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/pumpjack_bearing.json
@@ -10,7 +10,7 @@
       "item": "create:andesite_alloy"
     },
     "Z": {
-      "item": "create:zinc_ingot"
+      "tag": "c:zinc_ingots"
     },
     "B": {
       "item": "create:mechanical_bearing"

--- a/src/main/resources/data/createdieselgenerators/recipes/crafting/pumpjack_head.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/crafting/pumpjack_head.json
@@ -10,7 +10,7 @@
       "item": "create:andesite_alloy"
     },
     "Z": {
-      "item": "create:zinc_ingot"
+      "tag": "c:zinc_ingots"
     },
     "K": {
       "item": "minecraft:dried_kelp"

--- a/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/chemcial_sprayer.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/chemcial_sprayer.json
@@ -12,7 +12,7 @@
       "item": "create:fluid_pipe"
     },
     "C": {
-      "item": "minecraft:copper_block"
+      "tag": "c:copper_blocks"
     },
     "H": {
       "item": "createdieselgenerators:kelp_handle"

--- a/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/diesel_engine.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/diesel_engine.json
@@ -14,13 +14,13 @@
       "item": "minecraft:flint_and_steel"
     },
     "G": {
-      "item": "create:brass_block"
+      "tag": "c:brass_blocks"
     },
     "B": {
       "tag": "c:brass_plates"
     },
     "O": {
-      "item": "create:sturdy_sheet"
+      "tag": "c:obsidian_plates"
     },
     "S": {
       "item": "create:fluid_pipe"

--- a/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/large_diesel_engine.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/large_diesel_engine.json
@@ -16,7 +16,7 @@
       "item": "createdieselgenerators:diesel_engine"
     },
     "O": {
-      "item": "create:sturdy_sheet"
+      "tag": "c:obsidian_plates"
     },
     "S": {
       "tag": "c:brass_plates"

--- a/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/pumpjack_crank.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/mechanical_crafting/pumpjack_crank.json
@@ -12,10 +12,10 @@
       "item": "create:andesite_alloy"
     },
     "Z": {
-      "item": "create:zinc_ingot"
+      "tag": "c:zinc_ingots"
     },
     "I": {
-      "item": "create:iron_sheet"
+      "tag": "c:iron_plates"
     },
     "S": {
       "item": "create:shaft"

--- a/src/main/resources/data/createdieselgenerators/recipes/mixing/asphalt_block.json
+++ b/src/main/resources/data/createdieselgenerators/recipes/mixing/asphalt_block.json
@@ -6,7 +6,7 @@
       "count": 2
     },
     {
-      "item": "minecraft:sand",
+      "tag": "minecraft:sand",
       "count": 2
     },
     {


### PR DESCRIPTION
In all applicable recipes, replaces the remaining forge tag with the corresponding fabric tag and replaces some items with their fabric tag equivalent. I did poke around in the Create mod to see how they did things, so the new tags should follow their conventions as to when to use the fabric tag and when not to.

Conversions made:

- `"item": "minecraft:copper_block"` -> `"tag": "c:copper_blocks"`
- `"item": "create:sturdy_sheet"` -> `"tag": "c:obsidian_plates"`
- `"item": "create:iron_sheet"` -> `"tag": "c:iron_plates"`
- `"item": "create:brass_block"` -> `"tag": "c:brass_blocks"`
- `"item": "create:brass_sheet"` -> `"tag": "c:brass_plates"`
- `"item": "create:zinc_nugget"` -> `"tag": "c:zinc_nuggets"`
- `"item": "create:zinc_ingot"` -> `"tag": "c:zinc_ingots"`
  - see: george8188625/Create-Diesel-Generators#80
- `"tag": "c:nuggets/gold"` -> `"tag": "c:gold_nuggets"`
- `"item": "minecraft:gold_ingot"` -> `"tag": "c:gold_ingots"`
- `"item": "minecraft:string"` -> `"tag": "c:string"`
- `"item": "minecraft:sand"` -> `"tag": "minecraft:sand"`
- `"item": "create:wheat_flour"` -> `"tag": "c:wheat_flour"`

As a side effect, also fixes the broken golden carrot basin fermenting recipe.




